### PR TITLE
Fix: Prevent original data application to custom blocks in replace-block

### DIFF
--- a/blockregen-plugin/src/main/java/nl/aurorion/blockregen/regeneration/struct/RegenerationProcess.java
+++ b/blockregen-plugin/src/main/java/nl/aurorion/blockregen/regeneration/struct/RegenerationProcess.java
@@ -224,7 +224,7 @@ public class RegenerationProcess {
         }
 
         regenerateInto.setType(block);
-        originalData.apply(block); // Apply original data
+        if(regenerateInto instanceof MinecraftMaterial) originalData.apply(block); // Only apply original data for vanilla Minecraft materials, not custom blocks
         regenerateInto.applyData(block); // Override with configured data if any
         log.fine(() -> "Regenerated " + this);
     }
@@ -270,7 +270,7 @@ public class RegenerationProcess {
         }
 
         replaceMaterial.setType(block);
-        this.originalData.apply(block); // Apply original data
+        if(replaceMaterial instanceof MinecraftMaterial) this.originalData.apply(block); // Only apply original data for vanilla Minecraft materials, not custom blocks
         replaceMaterial.applyData(block); // Apply configured data if any
 
         // Otherwise skull textures wouldn't update.


### PR DESCRIPTION
## Problem
Oraxen blocks used in `replace-block` and `regenerate-into` were being instantly overwritten, causing them to skip the intermediate state and regenerate immediately.

## Fix
Only apply original block data to vanilla Minecraft materials, not custom blocks like Oraxen.

## Example
```yaml
chocolate_block:
  target-material: oraxen:chocolate_block
  replace-block: oraxen:temporary_block # Now works!
  regen-delay: 3
```

This fixes the issue where custom blocks in replace-block configurations were being instantly overwritten.