### PR TITLE
Provide MMOItem drops

### DIFF
--- a/blockregen-common/src/main/java/nl/aurorion/blockregen/Context.java
+++ b/blockregen-common/src/main/java/nl/aurorion/blockregen/Context.java
@@ -1,4 +1,4 @@
-package nl.aurorion.blockregen.conditional;
+package nl.aurorion.blockregen;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -8,10 +8,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-public class ConditionContext {
+public class Context {
     private final Map<String, Object> values;
 
-    ConditionContext(Map<String, Object> values) {
+    Context(Map<String, Object> values) {
         this.values = values;
     }
 
@@ -20,21 +20,21 @@ public class ConditionContext {
         return Collections.unmodifiableMap(this.values);
     }
 
-    public static ConditionContext of(String key, Object value) {
-        return new ConditionContext(new HashMap<String, Object>() {{
+    public static Context of(String key, Object value) {
+        return new Context(new HashMap<String, Object>() {{
             put(key, value);
         }});
     }
 
-    public static ConditionContext of(Map<String, Object> values) {
-        return new ConditionContext(values);
+    public static Context of(Map<String, Object> values) {
+        return new Context(values);
     }
 
-    public static ConditionContext empty() {
-        return new ConditionContext(new HashMap<>());
+    public static Context empty() {
+        return new Context(new HashMap<>());
     }
 
-    public ConditionContext with(String key, Object value) {
+    public Context with(String key, Object value) {
         this.values.put(key, value);
         return this;
     }
@@ -66,7 +66,7 @@ public class ConditionContext {
     }
 
     public Object mustVar(String key) {
-        return must(this.values.get(key));
+        return must(key, this.values.get(key));
     }
 
     public <T> T mustVar(String key, Class<T> as) {
@@ -74,8 +74,8 @@ public class ConditionContext {
     }
 
     @NotNull
-    private static <T> T must(T var) {
-        return Objects.requireNonNull(var, "var");
+    private static <T> T must(String key, T var) {
+        return Objects.requireNonNull(var, "Missing key '" + key + "'.");
     }
 
     public <T> T get(String key, Class<T> clazz) {

--- a/blockregen-conditional/pom.xml
+++ b/blockregen-conditional/pom.xml
@@ -12,6 +12,11 @@
     <artifactId>blockregen-conditional</artifactId>
 
     <dependencies>
+        <dependency>
+            <groupId>nl.aurorion.blockregen</groupId>
+            <artifactId>blockregen-common</artifactId>
+            <version>3.31.3</version>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/org.hamcrest/hamcrest-library -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/blockregen-conditional/src/main/java/nl/aurorion/blockregen/conditional/ComposedCondition.java
+++ b/blockregen-conditional/src/main/java/nl/aurorion/blockregen/conditional/ComposedCondition.java
@@ -1,6 +1,7 @@
 package nl.aurorion.blockregen.conditional;
 
 import lombok.Getter;
+import nl.aurorion.blockregen.Context;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -41,7 +42,7 @@ public class ComposedCondition extends Condition {
     }
 
     @Override
-    public boolean match(ConditionContext context) {
+    public boolean match(Context context) {
         if (relation == ConditionRelation.AND) {
             for (Condition condition : conditions) {
                 if (!condition.matches(context)) {

--- a/blockregen-conditional/src/main/java/nl/aurorion/blockregen/conditional/Condition.java
+++ b/blockregen-conditional/src/main/java/nl/aurorion/blockregen/conditional/Condition.java
@@ -1,5 +1,6 @@
 package nl.aurorion.blockregen.conditional;
 
+import nl.aurorion.blockregen.Context;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -30,7 +31,7 @@ public abstract class Condition {
     public static Condition of(@NotNull ConditionFunction function) {
         return new Condition() {
             @Override
-            public boolean match(ConditionContext context) {
+            public boolean match(Context context) {
                 return function.match(context);
             }
         };
@@ -40,7 +41,7 @@ public abstract class Condition {
     public static Condition of(@NotNull ConditionFunction function, String alias) {
         return new Condition(alias) {
             @Override
-            public boolean match(ConditionContext context) {
+            public boolean match(Context context) {
                 return function.match(context);
             }
         };
@@ -70,9 +71,9 @@ public abstract class Condition {
         return new ComposedCondition(ConditionRelation.AND, conditions);
     }
 
-    public abstract boolean match(ConditionContext context);
+    public abstract boolean match(Context context);
 
-    public boolean matches(ConditionContext context) {
+    public boolean matches(Context context) {
         return this.negate ^ this.match(context);
     }
 

--- a/blockregen-conditional/src/main/java/nl/aurorion/blockregen/conditional/ConditionFunction.java
+++ b/blockregen-conditional/src/main/java/nl/aurorion/blockregen/conditional/ConditionFunction.java
@@ -1,5 +1,7 @@
 package nl.aurorion.blockregen.conditional;
 
+import nl.aurorion.blockregen.Context;
+
 public interface ConditionFunction {
-    boolean match(ConditionContext context);
+    boolean match(Context context);
 }

--- a/blockregen-conditional/src/test/java/nl/aurorion/blockregen/ConditionTests.java
+++ b/blockregen-conditional/src/test/java/nl/aurorion/blockregen/ConditionTests.java
@@ -1,14 +1,14 @@
 package nl.aurorion.blockregen;
 
 import nl.aurorion.blockregen.conditional.Condition;
-import nl.aurorion.blockregen.conditional.ConditionContext;
+import nl.aurorion.blockregen.conditional.Context;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 public class ConditionTests {
 
-    private static final ConditionContext EMPTY_CONTEXT = ConditionContext.empty();
+    private static final Context EMPTY_CONTEXT = Context.empty();
 
     @Test
     public void evaluatesSingleValueExpressions() {
@@ -35,7 +35,7 @@ public class ConditionTests {
 
     @Test
     public void evaluatesBasedOnContextValues() {
-        ConditionContext context = ConditionContext.of("value", 10);
+        Context context = Context.of("value", 10);
         Condition c1 = Condition.of((ctx) -> {
             return (int) ctx.mustVar("value") > 5;
         });
@@ -49,7 +49,7 @@ public class ConditionTests {
             return true;
         });
 
-        ConditionContext context = ConditionContext.of("hello", "world");
+        Context context = Context.of("hello", "world");
 
         assertTrue(condition.matches(context));
         assertTrue(context.get("from_condition", Boolean.class));
@@ -60,7 +60,7 @@ public class ConditionTests {
         // true and true
         Condition composed = Condition.truthy().and(Condition.truthy());
 
-        ConditionContext context = ConditionContext.empty();
+        Context context = Context.empty();
 
         assertTrue(composed.matches(context));
 

--- a/blockregen-conditional/src/test/java/nl/aurorion/blockregen/ConditionTests.java
+++ b/blockregen-conditional/src/test/java/nl/aurorion/blockregen/ConditionTests.java
@@ -1,7 +1,6 @@
 package nl.aurorion.blockregen;
 
 import nl.aurorion.blockregen.conditional.Condition;
-import nl.aurorion.blockregen.conditional.Context;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/blockregen-plugin/src/main/java/nl/aurorion/blockregen/compatibility/provider/JobsProvider.java
+++ b/blockregen-plugin/src/main/java/nl/aurorion/blockregen/compatibility/provider/JobsProvider.java
@@ -7,7 +7,7 @@ import com.gamingmesh.jobs.container.Job;
 import com.gamingmesh.jobs.container.JobProgression;
 import com.gamingmesh.jobs.container.JobsPlayer;
 import nl.aurorion.blockregen.conditional.Condition;
-import nl.aurorion.blockregen.conditional.ConditionContext;
+import nl.aurorion.blockregen.Context;
 import lombok.extern.java.Log;
 import nl.aurorion.blockregen.ParseException;
 import nl.aurorion.blockregen.BlockRegenPlugin;
@@ -37,7 +37,7 @@ public class JobsProvider extends CompatibilityProvider {
         }).extender((ctx) -> {
             Player player = (Player) ctx.mustVar("player");
             JobsPlayer jobsPlayer = Jobs.getPlayerManager().getJobsPlayer(player);
-            return ConditionContext.of("jobs.player", jobsPlayer);
+            return Context.of("jobs.player", jobsPlayer);
         });
     }
 

--- a/blockregen-plugin/src/main/java/nl/aurorion/blockregen/compatibility/provider/MMOItemsProvider.java
+++ b/blockregen-plugin/src/main/java/nl/aurorion/blockregen/compatibility/provider/MMOItemsProvider.java
@@ -146,13 +146,13 @@ public class MMOItemsProvider extends CompatibilityProvider implements ItemProvi
             throw new ParseException("Invalid input for MMOItems tool. Has to have the format of <type>:<id>.");
         }
 
-        String typeName = matcher.group(1);
+        String typeName = matcher.group(1).toUpperCase();
         Type type = MMOItems.plugin.getTypes().get(typeName);
         if (type == null) {
             throw new ParseException("Invalid MMOItems item type " + typeName + ".");
         }
 
-        String itemId = matcher.group(2);
+        String itemId = matcher.group(2).toUpperCase();
         return MMOItems.plugin.getMMOItem(type, itemId);
     }
 

--- a/blockregen-plugin/src/main/java/nl/aurorion/blockregen/compatibility/provider/MMOItemsProvider.java
+++ b/blockregen-plugin/src/main/java/nl/aurorion/blockregen/compatibility/provider/MMOItemsProvider.java
@@ -165,7 +165,7 @@ public class MMOItemsProvider extends CompatibilityProvider implements ItemProvi
         Matcher matcher = ITEM_PATTERN.matcher(id);
 
         if (!matcher.matches()) {
-            throw new ParseException("Invalid input for MMOItems tool. Has to have the format of <type>:<id>.");
+            throw new ParseException("Invalid input for MMOItem. Has to have the format of '<type>:<id>'.");
         }
 
         String typeName = matcher.group(1).toUpperCase();
@@ -176,6 +176,10 @@ public class MMOItemsProvider extends CompatibilityProvider implements ItemProvi
         }
 
         String itemId = matcher.group(2).toUpperCase();
+
+        if (player == null) {
+            return MMOItems.plugin.getMMOItem(type, itemId);
+        }
 
         PlayerData playerData = MMOItems.plugin.getPlayerDataManager().get(player);
 

--- a/blockregen-plugin/src/main/java/nl/aurorion/blockregen/compatibility/provider/MMOItemsProvider.java
+++ b/blockregen-plugin/src/main/java/nl/aurorion/blockregen/compatibility/provider/MMOItemsProvider.java
@@ -4,27 +4,32 @@ import io.lumine.mythic.lib.api.item.NBTItem;
 import net.Indyuce.mmoitems.MMOItems;
 import net.Indyuce.mmoitems.api.Type;
 import net.Indyuce.mmoitems.api.block.CustomBlock;
+import net.Indyuce.mmoitems.api.item.build.ItemStackBuilder;
 import net.Indyuce.mmoitems.api.item.mmoitem.MMOItem;
 import nl.aurorion.blockregen.BlockRegenPlugin;
 import nl.aurorion.blockregen.ParseException;
 import nl.aurorion.blockregen.compatibility.CompatibilityProvider;
 import nl.aurorion.blockregen.compatibility.material.MMOItemsMaterial;
 import nl.aurorion.blockregen.conditional.Condition;
+import nl.aurorion.blockregen.drop.ItemProvider;
 import nl.aurorion.blockregen.material.BlockRegenMaterial;
 import nl.aurorion.blockregen.material.MaterialProvider;
 import org.bukkit.block.Block;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
-public class MMOItemsProvider extends CompatibilityProvider implements MaterialProvider {
+public class MMOItemsProvider extends CompatibilityProvider implements ItemProvider, MaterialProvider {
     public MMOItemsProvider(BlockRegenPlugin plugin) {
         super(plugin, "mmoitems");
-        setFeatures("materials", "conditions");
+        setFeatures("materials", "conditions", "drops");
     }
 
     private static final Pattern ITEM_PATTERN = Pattern.compile("(\\S+):(\\S+)");
@@ -35,26 +40,10 @@ public class MMOItemsProvider extends CompatibilityProvider implements MaterialP
         // https://gitlab.com/phoenix-dvpmt/mmoitems/-/wikis/Main%20API%20Features#checking-if-an-itemstack-is-from-mi
         plugin.getPresetManager().getConditions().addProvider(getPrefix() + "/tool", ((key, node) -> {
 
-            Matcher matcher = ITEM_PATTERN.matcher((String) node);
-
-            if (!matcher.matches()) {
-                throw new ParseException("Invalid input for MMOItems tool. Has to have the format of <type>:<id>.");
-            }
-
-            String typeName = matcher.group(1);
-
-            Type type = MMOItems.plugin.getTypes().get(typeName);
-
-            if (type == null) {
-                throw new ParseException("Invalid MMOItems item type " + typeName + ".");
-            }
-
-            String id = matcher.group(2);
-
-            MMOItem item = MMOItems.plugin.getMMOItem(type, id);
+            final MMOItem item = getMMOItem((String) node);
 
             if (item == null) {
-                throw new ParseException("Invalid MMOItems item '" + type + ":" + id + "'.", true);
+                throw new ParseException("Invalid MMOItems item '" + node + "'.", true);
             }
 
             return Condition.of((ctx) -> {
@@ -71,13 +60,13 @@ public class MMOItemsProvider extends CompatibilityProvider implements MaterialP
 
                 String toolType = nbtItem.getType();
 
-                if (!toolType.equalsIgnoreCase(typeName)) {
+                if (!toolType.equalsIgnoreCase(item.getType().getName())) {
                     return false;
                 }
 
                 String toolId = nbtItem.getString("MMOITEMS_ITEM_ID");
 
-                if (!toolId.equalsIgnoreCase(id)) {
+                if (!toolId.equalsIgnoreCase(item.getId())) {
                     return false;
                 }
 
@@ -123,4 +112,48 @@ public class MMOItemsProvider extends CompatibilityProvider implements MaterialP
     public BlockRegenMaterial createInstance(java.lang.reflect.Type type) {
         return new MMOItemsMaterial(-1);
     }
+
+    @Override
+    public @Nullable ItemStack createItem(@NonNull String id, @NonNull Function<String, String> parser, int amount) {
+        final MMOItem mmoItem = getMMOItem(id);
+
+        if (mmoItem == null) {
+            return null;
+        }
+
+        ItemStackBuilder itemBuilder = mmoItem.newBuilder();
+        itemBuilder.getLore().setLore(itemBuilder.getLore().getLore().stream().map(parser).collect(Collectors.toList()));
+        if (itemBuilder.getMeta().hasDisplayName()) {
+            itemBuilder.getMeta().setDisplayName(parser.apply(itemBuilder.getMeta().getDisplayName()));
+        }
+
+        ItemStack itemStack = itemBuilder.build();
+        if (itemStack != null) {
+            itemStack.setAmount(amount);
+        }
+
+        return itemStack;
+    }
+
+    @Override
+    public boolean exists(@NonNull String id) {
+        return getMMOItem(id) != null;
+    }
+
+    private MMOItem getMMOItem(@NonNull String id) {
+        Matcher matcher = ITEM_PATTERN.matcher(id);
+        if (!matcher.matches()) {
+            throw new ParseException("Invalid input for MMOItems tool. Has to have the format of <type>:<id>.");
+        }
+
+        String typeName = matcher.group(1);
+        Type type = MMOItems.plugin.getTypes().get(typeName);
+        if (type == null) {
+            throw new ParseException("Invalid MMOItems item type " + typeName + ".");
+        }
+
+        String itemId = matcher.group(2);
+        return MMOItems.plugin.getMMOItem(type, itemId);
+    }
+
 }

--- a/blockregen-plugin/src/main/java/nl/aurorion/blockregen/compatibility/provider/MMOItemsProvider.java
+++ b/blockregen-plugin/src/main/java/nl/aurorion/blockregen/compatibility/provider/MMOItemsProvider.java
@@ -37,7 +37,7 @@ public class MMOItemsProvider extends CompatibilityProvider implements ItemProvi
     @Override
     public void onLoad() {
         // Register conditions provider.
-        // https://gitlab.com/phoenix-dvpmt/mmoitems/-/wikis/Main%20API%20Features#checking-if-an-itemstack-is-from-mi
+        // https://docs.phoenixdevt.fr/mmoitems/api/main.html#checking-if-an-itemstack-is-from-mi
         plugin.getPresetManager().getConditions().addProvider(getPrefix() + "/tool", ((key, node) -> {
 
             final MMOItem item = getMMOItem((String) node);

--- a/blockregen-plugin/src/main/java/nl/aurorion/blockregen/drop/ItemProvider.java
+++ b/blockregen-plugin/src/main/java/nl/aurorion/blockregen/drop/ItemProvider.java
@@ -1,5 +1,6 @@
 package nl.aurorion.blockregen.drop;
 
+import nl.aurorion.blockregen.Context;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -11,7 +12,15 @@ public interface ItemProvider {
 
     // Provide an ItemStack. Run all strings through the parser (lore, name).
     @Nullable
+    // Deprecated: use #createItem(Context)
+    @Deprecated
     ItemStack createItem(@NotNull String id, @NotNull Function<String, String> parser, int amount);
+
+    @SuppressWarnings("unchecked")
+    @Nullable
+    default ItemStack createItem(@NotNull String id, int amount, @NotNull Context context) {
+        return createItem(id, (Function<String, String>) context.mustVar("parser"), amount);
+    }
 
     // Verify that this item exists.
     boolean exists(@NotNull String id);

--- a/blockregen-plugin/src/main/java/nl/aurorion/blockregen/preset/condition/ConditionWrapper.java
+++ b/blockregen-plugin/src/main/java/nl/aurorion/blockregen/preset/condition/ConditionWrapper.java
@@ -3,7 +3,7 @@ package nl.aurorion.blockregen.preset.condition;
 
 import lombok.extern.java.Log;
 import nl.aurorion.blockregen.conditional.Condition;
-import nl.aurorion.blockregen.conditional.ConditionContext;
+import nl.aurorion.blockregen.Context;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -19,15 +19,15 @@ public class ConditionWrapper extends Condition {
         this.extender = extender;
     }
 
-    private ConditionContext extend(ConditionContext original) {
+    private Context extend(Context original) {
         if (this.extender == null) {
             return original;
         }
 
-        ConditionContext result = original;
+        Context result = original;
 
         try {
-            ConditionContext additional = this.extender.extend(original);
+            Context additional = this.extender.extend(original);
 
             // Just in case somebody returns the original.
             if (additional != result) {
@@ -42,8 +42,8 @@ public class ConditionWrapper extends Condition {
     }
 
     @Override
-    public boolean match(ConditionContext original) {
-        ConditionContext context = this.extend(original);
+    public boolean match(Context original) {
+        Context context = this.extend(original);
         return this.composed.matches(context);
     }
 

--- a/blockregen-plugin/src/main/java/nl/aurorion/blockregen/preset/condition/Conditions.java
+++ b/blockregen-plugin/src/main/java/nl/aurorion/blockregen/preset/condition/Conditions.java
@@ -2,7 +2,7 @@ package nl.aurorion.blockregen.preset.condition;
 
 import nl.aurorion.blockregen.ParseException;
 import nl.aurorion.blockregen.conditional.Condition;
-import nl.aurorion.blockregen.conditional.ConditionContext;
+import nl.aurorion.blockregen.Context;
 import org.bukkit.configuration.ConfigurationSection;
 import org.jetbrains.annotations.NotNull;
 
@@ -136,14 +136,14 @@ public class Conditions {
      * @return A new ConditionContext containing the merged variables.
      */
     @NotNull
-    public static ConditionContext mergeContexts(ConditionContext... contexts) {
+    public static Context mergeContexts(Context... contexts) {
         Map<String, Object> result = new HashMap<>();
 
-        for (ConditionContext context : contexts) {
+        for (Context context : contexts) {
             Map<String, Object> vars = context.values();
             result.putAll(vars);
         }
-        return ConditionContext.of(result);
+        return Context.of(result);
     }
 
     /**

--- a/blockregen-plugin/src/main/java/nl/aurorion/blockregen/preset/condition/ContextExtender.java
+++ b/blockregen-plugin/src/main/java/nl/aurorion/blockregen/preset/condition/ContextExtender.java
@@ -1,6 +1,6 @@
 package nl.aurorion.blockregen.preset.condition;
 
-import nl.aurorion.blockregen.conditional.ConditionContext;
+import nl.aurorion.blockregen.Context;
 import org.jetbrains.annotations.NotNull;
 
 public interface ContextExtender {
@@ -12,5 +12,5 @@ public interface ContextExtender {
      * @return Newly provided context.
      */
     @NotNull
-    ConditionContext extend(@NotNull ConditionContext ctx);
+    Context extend(@NotNull Context ctx);
 }

--- a/blockregen-plugin/src/main/java/nl/aurorion/blockregen/preset/condition/DefaultConditions.java
+++ b/blockregen-plugin/src/main/java/nl/aurorion/blockregen/preset/condition/DefaultConditions.java
@@ -8,7 +8,7 @@ import nl.aurorion.blockregen.BlockRegenPluginImpl;
 import nl.aurorion.blockregen.Pair;
 import nl.aurorion.blockregen.ParseException;
 import nl.aurorion.blockregen.conditional.Condition;
-import nl.aurorion.blockregen.conditional.ConditionContext;
+import nl.aurorion.blockregen.Context;
 import nl.aurorion.blockregen.preset.FixedNumberValue;
 import nl.aurorion.blockregen.preset.NumberValue;
 import nl.aurorion.blockregen.preset.condition.expression.Expression;
@@ -70,7 +70,7 @@ public class DefaultConditions {
                                         }
                                     }
 
-                                    return ConditionContext.empty()
+                                    return Context.empty()
                                             .with("material", material)
                                             .with("enchants", item == null ? new HashMap<>() : item.getEnchantments());
                                 }), ConditionRelation.AND)

--- a/blockregen-plugin/src/main/java/nl/aurorion/blockregen/preset/condition/expression/Constant.java
+++ b/blockregen-plugin/src/main/java/nl/aurorion/blockregen/preset/condition/expression/Constant.java
@@ -1,6 +1,6 @@
 package nl.aurorion.blockregen.preset.condition.expression;
 
-import nl.aurorion.blockregen.conditional.ConditionContext;
+import nl.aurorion.blockregen.Context;
 import lombok.Getter;
 
 public class Constant implements Operand {
@@ -12,7 +12,7 @@ public class Constant implements Operand {
     }
 
     @Override
-    public Object value(ConditionContext ctx) {
+    public Object value(Context ctx) {
         return this.value;
     }
 

--- a/blockregen-plugin/src/main/java/nl/aurorion/blockregen/preset/condition/expression/Expression.java
+++ b/blockregen-plugin/src/main/java/nl/aurorion/blockregen/preset/condition/expression/Expression.java
@@ -1,7 +1,7 @@
 package nl.aurorion.blockregen.preset.condition.expression;
 
 import com.google.common.base.Strings;
-import nl.aurorion.blockregen.conditional.ConditionContext;
+import nl.aurorion.blockregen.Context;
 import lombok.Getter;
 import lombok.extern.java.Log;
 import nl.aurorion.blockregen.ParseException;
@@ -49,7 +49,7 @@ public class Expression {
     /**
      * @throws ParseException If the comparator cannot get objects of comparable types.
      * */
-    public boolean evaluate(@NotNull ConditionContext ctx) {
+    public boolean evaluate(@NotNull Context ctx) {
         if (isConstant()) {
             return this.staticResult;
         }

--- a/blockregen-plugin/src/main/java/nl/aurorion/blockregen/preset/condition/expression/Operand.java
+++ b/blockregen-plugin/src/main/java/nl/aurorion/blockregen/preset/condition/expression/Operand.java
@@ -1,7 +1,7 @@
 package nl.aurorion.blockregen.preset.condition.expression;
 
 import com.google.common.base.Strings;
-import nl.aurorion.blockregen.conditional.ConditionContext;
+import nl.aurorion.blockregen.Context;
 import lombok.extern.java.Log;
 import nl.aurorion.blockregen.ParseException;
 import org.jetbrains.annotations.NotNull;
@@ -13,7 +13,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public interface Operand {
-    Object value(ConditionContext ctx);
+    Object value(Context ctx);
 
     Pattern PLACEHOLDER_PATTERN = Pattern.compile("(%\\S+%)");
 

--- a/blockregen-plugin/src/main/java/nl/aurorion/blockregen/preset/condition/expression/Variable.java
+++ b/blockregen-plugin/src/main/java/nl/aurorion/blockregen/preset/condition/expression/Variable.java
@@ -1,6 +1,6 @@
 package nl.aurorion.blockregen.preset.condition.expression;
 
-import nl.aurorion.blockregen.conditional.ConditionContext;
+import nl.aurorion.blockregen.Context;
 import lombok.Getter;
 import me.clip.placeholderapi.PlaceholderAPI;
 import nl.aurorion.blockregen.BlockRegenPlugin;
@@ -18,7 +18,7 @@ public class Variable implements Operand {
     }
 
     @Override
-    public Object value(ConditionContext ctx) {
+    public Object value(Context ctx) {
         String result = Text.parse(content, ctx.values().values().toArray());
         if (BlockRegenPlugin.getInstance().isUsePlaceholderAPI()) {
             result = PlaceholderAPI.setPlaceholders((Player) ctx.mustVar("player"), result);

--- a/blockregen-plugin/src/main/java/nl/aurorion/blockregen/preset/drop/DropItem.java
+++ b/blockregen-plugin/src/main/java/nl/aurorion/blockregen/preset/drop/DropItem.java
@@ -1,5 +1,6 @@
 package nl.aurorion.blockregen.preset.drop;
 
+import nl.aurorion.blockregen.Context;
 import nl.aurorion.blockregen.conditional.Condition;
 import lombok.Getter;
 import lombok.Setter;
@@ -33,7 +34,7 @@ public abstract class DropItem {
     protected Condition condition;
 
     // Serialize this drop into an item stack.
-    public abstract ItemStack toItemStack(Function<String, String> parser);
+    public abstract ItemStack toItemStack(Context context);
 
     public boolean shouldDrop() {
         // x/100% chance to drop

--- a/blockregen-plugin/src/main/java/nl/aurorion/blockregen/preset/drop/ExternalDropItem.java
+++ b/blockregen-plugin/src/main/java/nl/aurorion/blockregen/preset/drop/ExternalDropItem.java
@@ -1,11 +1,9 @@
 package nl.aurorion.blockregen.preset.drop;
 
+import nl.aurorion.blockregen.Context;
 import nl.aurorion.blockregen.drop.ItemProvider;
 import org.bukkit.inventory.ItemStack;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.function.Function;
 
 public class ExternalDropItem extends DropItem {
 
@@ -19,12 +17,12 @@ public class ExternalDropItem extends DropItem {
 
     @Override
     @Nullable
-    public ItemStack toItemStack(@NotNull Function<String, String> parser) {
+    public ItemStack toItemStack(Context context) {
         int amount = this.amount.getInt();
         if (amount <= 0) {
             return null;
         }
-        return provider.createItem(this.id, parser, amount);
+        return provider.createItem(this.id, amount, context);
     }
 
     @Override

--- a/blockregen-plugin/src/main/java/nl/aurorion/blockregen/preset/drop/MinecraftDropItem.java
+++ b/blockregen-plugin/src/main/java/nl/aurorion/blockregen/preset/drop/MinecraftDropItem.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.java.Log;
 import nl.aurorion.blockregen.BlockRegenPluginImpl;
+import nl.aurorion.blockregen.Context;
 import nl.aurorion.blockregen.util.Colors;
 import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.ItemFlag;
@@ -50,9 +51,10 @@ public class MinecraftDropItem extends DropItem {
      *
      * @return Created item stack.
      */
+    @SuppressWarnings("unchecked")
     @Nullable
     @Override
-    public ItemStack toItemStack(Function<String, String> parser) {
+    public ItemStack toItemStack(Context context) {
         int amount = this.amount.getInt();
         if (amount <= 0) {
             return null;
@@ -71,6 +73,8 @@ public class MinecraftDropItem extends DropItem {
         if (itemMeta == null) {
             return null;
         }
+
+        final Function<String, String> parser = (Function<String, String>) context.mustVar("parser");
 
         if (displayName != null) {
             itemMeta.setDisplayName(Colors.color(parser.apply(displayName)));

--- a/blockregen-plugin/src/main/resources/plugin.yml
+++ b/blockregen-plugin/src/main/resources/plugin.yml
@@ -2,7 +2,7 @@ name: BlockRegen
 main: nl.aurorion.blockregen.BlockRegenPluginImpl
 version: ${project.version}
 authors: [ Aurorion, Wertik1206 ]
-contributors: [ czmdav ]
+contributors: [ czmdav, CinturonCris, OlivierChiasson, gustaavik ]
 softdepend:
   - Mutliverse-Core
   - Residence

--- a/blockregen-plugin/src/main/resources/plugin.yml
+++ b/blockregen-plugin/src/main/resources/plugin.yml
@@ -2,6 +2,7 @@ name: BlockRegen
 main: nl.aurorion.blockregen.BlockRegenPluginImpl
 version: ${project.version}
 authors: [ Aurorion, Wertik1206 ]
+contributors: [ czmdav ]
 softdepend:
   - Mutliverse-Core
   - Residence

--- a/blockregen-plugin/src/test/java/nl/aurorion/blockregen/ConditionLoadingTests.java
+++ b/blockregen-plugin/src/test/java/nl/aurorion/blockregen/ConditionLoadingTests.java
@@ -2,7 +2,6 @@ package nl.aurorion.blockregen;
 
 import lombok.extern.java.Log;
 import nl.aurorion.blockregen.conditional.Condition;
-import nl.aurorion.blockregen.conditional.ConditionContext;
 import nl.aurorion.blockregen.preset.condition.ConditionProvider;
 import nl.aurorion.blockregen.preset.condition.ConditionRelation;
 import nl.aurorion.blockregen.preset.condition.Conditions;
@@ -49,9 +48,9 @@ public class ConditionLoadingTests {
 
         assertEquals("above", condition.alias());
 
-        ConditionContext ctx = ConditionContext.of("value", 3);
+        Context ctx = Context.of("value", 3);
         assertTrue(condition.matches(ctx));
-        ctx = ConditionContext.of("value", 1);
+        ctx = Context.of("value", 1);
         assertFalse(condition.matches(ctx));
     }
 
@@ -64,9 +63,9 @@ public class ConditionLoadingTests {
 
         assertEquals("!above", condition.alias());
 
-        ConditionContext ctx = ConditionContext.of("value", 1);
+        Context ctx = Context.of("value", 1);
         assertTrue(condition.matches(ctx));
-        ctx = ConditionContext.of("value", 4);
+        ctx = Context.of("value", 4);
         assertFalse(condition.matches(ctx));
     }
 
@@ -79,9 +78,9 @@ public class ConditionLoadingTests {
 
         assertEquals("(!below and below)", condition.alias());
 
-        assertFalse(condition.matches(ConditionContext.of("value", 1)));
-        assertTrue(condition.matches(ConditionContext.of("value", 3)));
-        assertFalse(condition.matches(ConditionContext.of("value", 6)));
+        assertFalse(condition.matches(Context.of("value", 1)));
+        assertTrue(condition.matches(Context.of("value", 3)));
+        assertFalse(condition.matches(Context.of("value", 6)));
     }
 
     @Test
@@ -99,13 +98,13 @@ public class ConditionLoadingTests {
 
         assertEquals("(above and above)", condition.alias());
 
-        ConditionContext ctx = ConditionContext.of("value", 4);
+        Context ctx = Context.of("value", 4);
         assertFalse(condition.matches(ctx));
 
-        ctx = ConditionContext.of("value", 5);
+        ctx = Context.of("value", 5);
         assertFalse(condition.matches(ctx));
 
-        ctx = ConditionContext.of("value", 15);
+        ctx = Context.of("value", 15);
         assertTrue(condition.matches(ctx));
     }
 
@@ -117,13 +116,13 @@ public class ConditionLoadingTests {
 
         assertEquals("(below or above)", condition.alias());
 
-        ConditionContext ctx = ConditionContext.of("value", 1);
+        Context ctx = Context.of("value", 1);
         assertTrue(condition.matches(ctx));
 
-        ctx = ConditionContext.of("value", 5);
+        ctx = Context.of("value", 5);
         assertFalse(condition.matches(ctx));
 
-        ctx = ConditionContext.of("value", 15);
+        ctx = Context.of("value", 15);
         assertTrue(condition.matches(ctx));
     }
 
@@ -136,16 +135,16 @@ public class ConditionLoadingTests {
 
         assertEquals("(below and (below or equals))", condition.alias());
 
-        ConditionContext ctx = ConditionContext.of("value", 1);
+        Context ctx = Context.of("value", 1);
         assertTrue(condition.matches(ctx));
 
-        ctx = ConditionContext.of("value", 3);
+        ctx = Context.of("value", 3);
         assertTrue(condition.matches(ctx));
 
-        ctx = ConditionContext.of("value", 4);
+        ctx = Context.of("value", 4);
         assertFalse(condition.matches(ctx));
 
-        ctx = ConditionContext.of("value", 6);
+        ctx = Context.of("value", 6);
         assertFalse(condition.matches(ctx));
     }
 
@@ -159,9 +158,9 @@ public class ConditionLoadingTests {
 
         assertEquals("(above and below)", condition.alias());
 
-        assertFalse(condition.matches(ConditionContext.of("value", 1)));
-        assertTrue(condition.matches(ConditionContext.of("value", 6)));
-        assertFalse(condition.matches(ConditionContext.of("value", 16)));
+        assertFalse(condition.matches(Context.of("value", 1)));
+        assertTrue(condition.matches(Context.of("value", 6)));
+        assertFalse(condition.matches(Context.of("value", 16)));
     }
 
     @Test()
@@ -176,7 +175,7 @@ public class ConditionLoadingTests {
                         return (double) ctx.mustVar("sqrt") > (int) node;
                     });
                 })
-                .extender((ctx) -> ConditionContext.of("sqrt", Math.sqrt((int) ctx.mustVar("value"))));
+                .extender((ctx) -> Context.of("sqrt", Math.sqrt((int) ctx.mustVar("value"))));
 
         ConditionProvider baseProvider = GenericConditionProvider.empty()
                 .addProvider("below", (key, node) -> {
@@ -191,9 +190,9 @@ public class ConditionLoadingTests {
 
         assertEquals("(above and below)", condition.alias());
 
-        assertFalse(condition.matches(ConditionContext.of("value", 1)));
-        assertTrue(condition.matches(ConditionContext.of("value", 6)));
-        assertFalse(condition.matches(ConditionContext.of("value", 16)));
+        assertFalse(condition.matches(Context.of("value", 1)));
+        assertTrue(condition.matches(Context.of("value", 6)));
+        assertFalse(condition.matches(Context.of("value", 16)));
     }
 
     @Test
@@ -203,9 +202,9 @@ public class ConditionLoadingTests {
         FileConfiguration conf = YamlConfiguration.loadConfiguration(new StringReader(input));
         Condition condition = Conditions.fromMap(Objects.requireNonNull(conf.getValues(false)), ConditionRelation.AND, conditionProvider);
 
-        assertFalse(condition.matches(ConditionContext.of("value", 1)));
-        assertTrue(condition.matches(ConditionContext.of("value", 3)));
-        assertFalse(condition.matches(ConditionContext.of("value", 6)));
+        assertFalse(condition.matches(Context.of("value", 1)));
+        assertTrue(condition.matches(Context.of("value", 3)));
+        assertFalse(condition.matches(Context.of("value", 6)));
     }
 
     @Test
@@ -215,20 +214,20 @@ public class ConditionLoadingTests {
                 (ctx) -> {
                     // Take value and sqrt it
                     int v = (int) ctx.mustVar("value");
-                    return ConditionContext.of("sqrt", Math.sqrt(v));
+                    return Context.of("sqrt", Math.sqrt(v));
                 }
         );
 
         assertEquals("sqrt > 2", condition.alias());
-        assertTrue(condition.matches(ConditionContext.of("value", 9)));
+        assertTrue(condition.matches(Context.of("value", 9)));
     }
 
     @Test
     public void mergesContexts() {
-        ConditionContext context = ConditionContext.of("value", 1);
-        ConditionContext context1 = ConditionContext.of("random", 2);
+        Context context = Context.of("value", 1);
+        Context context1 = Context.of("random", 2);
 
-        ConditionContext merged = Conditions.mergeContexts(context, context1);
+        Context merged = Conditions.mergeContexts(context, context1);
 
         assertEquals(1, merged.mustVar("value"));
         assertEquals(2, merged.mustVar("random"));
@@ -236,10 +235,10 @@ public class ConditionLoadingTests {
 
     @Test
     public void mergesContextsOverridesValues() {
-        ConditionContext context = ConditionContext.of("value", 1);
-        ConditionContext context1 = ConditionContext.of("value", 2);
+        Context context = Context.of("value", 1);
+        Context context1 = Context.of("value", 2);
 
-        ConditionContext merged = Conditions.mergeContexts(context, context1);
+        Context merged = Conditions.mergeContexts(context, context1);
 
         assertEquals(2, merged.mustVar("value"));
     }


### PR DESCRIPTION
Though this is not a full implementation, gets the job done prety well.

The MMOItems [documentaion says](https://docs.phoenixdevt.fr/mmoitems/api/main.html#checking-if-an-itemstack-is-from-mi:~:text=Note%20however%2C%20that%20using%20this%20method%20will%20return%20an%20item%20that%20is%20not%20scaled%20with%20the%20player%20level%20and%20without%20a%20randomized%20tier):
> Note however, that this method will return an item that is not scaled with the player level and without a randomized tier.

In order to make the item generation respect the player's level, the ItemProvider structure needs a bigger change.