### PR TITLE
fix: preserve CustomModelData when dropping MythicMobs items

### DIFF
--- a/blockregen-plugin/src/main/java/nl/aurorion/blockregen/compatibility/provider/MythicMobsProvider.java
+++ b/blockregen-plugin/src/main/java/nl/aurorion/blockregen/compatibility/provider/MythicMobsProvider.java
@@ -6,12 +6,15 @@ import io.lumine.mythic.core.items.MythicItem;
 import nl.aurorion.blockregen.BlockRegenPlugin;
 import nl.aurorion.blockregen.compatibility.CompatibilityProvider;
 import nl.aurorion.blockregen.drop.ItemProvider;
+import org.bukkit.Bukkit;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -32,6 +35,27 @@ public class MythicMobsProvider extends CompatibilityProvider implements ItemPro
         }
 
         MythicItem mythicItem = item.get();
+
+        // MythicMobs item generation is not thread-safe and must run on the main thread.
+        // If called from an async context (e.g. BlockRegen's reward processing), dispatch
+        // to the main thread and block until the result is ready.
+        if (!Bukkit.isPrimaryThread()) {
+            CompletableFuture<ItemStack> future = new CompletableFuture<>();
+            Bukkit.getScheduler().runTask(plugin, () -> future.complete(buildItemStack(mythicItem, parser, amount)));
+            try {
+                return future.get();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return null;
+            } catch (ExecutionException e) {
+                return null;
+            }
+        }
+
+        return buildItemStack(mythicItem, parser, amount);
+    }
+
+    private ItemStack buildItemStack(MythicItem mythicItem, Function<String, String> parser, int amount) {
         BukkitItemStack itemStack = (BukkitItemStack) mythicItem.generateItemStack(amount);
 
         // Get the fully rendered Bukkit ItemStack (with CustomModelData and all MythicMobs metadata intact).

--- a/blockregen-plugin/src/main/java/nl/aurorion/blockregen/compatibility/provider/MythicMobsProvider.java
+++ b/blockregen-plugin/src/main/java/nl/aurorion/blockregen/compatibility/provider/MythicMobsProvider.java
@@ -7,8 +7,10 @@ import nl.aurorion.blockregen.BlockRegenPlugin;
 import nl.aurorion.blockregen.compatibility.CompatibilityProvider;
 import nl.aurorion.blockregen.drop.ItemProvider;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -32,10 +34,25 @@ public class MythicMobsProvider extends CompatibilityProvider implements ItemPro
         MythicItem mythicItem = item.get();
         BukkitItemStack itemStack = (BukkitItemStack) mythicItem.generateItemStack(amount);
 
-        itemStack.setLore(mythicItem.getLore().stream().map(parser).collect(Collectors.toList()));
-        itemStack.setName(parser.apply(mythicItem.getDisplayName()));
+        // Get the fully rendered Bukkit ItemStack (with CustomModelData and all MythicMobs metadata intact).
+        // Modify only name/lore through Bukkit's ItemMeta to avoid wiping CustomModelData,
+        // which happened when calling BukkitItemStack.setName/setLore directly.
+        ItemStack bukkitStack = itemStack.getItemStack();
+        ItemMeta meta = bukkitStack.getItemMeta();
+        if (meta != null) {
+            if (meta.hasDisplayName()) {
+                meta.setDisplayName(parser.apply(meta.getDisplayName()));
+            }
+            if (meta.hasLore()) {
+                List<String> lore = meta.getLore();
+                if (lore != null) {
+                    meta.setLore(lore.stream().map(parser).collect(Collectors.toList()));
+                }
+            }
+            bukkitStack.setItemMeta(meta);
+        }
 
-        return itemStack.getItemStack();
+        return bukkitStack;
     }
 
     @Override


### PR DESCRIPTION
## Problem

When a block drops an item configured with `item: mythic:<id>`, the
resulting ItemStack sometimes had no CustomModelData.

After generating the item via `mythicItem.generateItemStack(amount)`,
the code was calling `BukkitItemStack.setName()` and `BukkitItemStack.setLore()`
on the MythicMobs wrapper. These calls reconstruct the ItemMeta internally,
wiping metadata set by MythicMobs during generation — including CustomModelData,
attribute modifiers, and other NBT data.

Additionally, the lore/name passed came from `mythicItem.getLore()` /
`mythicItem.getDisplayName()` — the raw config strings, before MythicMobs'
own rendering pipeline (color codes, MM placeholders, etc.).

## Fix

Retrieve the Bukkit `ItemStack` directly from the generated result, then
apply BlockRegen's parser to the existing `ItemMeta` via the standard
Bukkit API. This preserves all metadata (including CustomModelData) while
still allowing BlockRegen placeholders in name and lore.

## Reproduction

```yaml
carrots:
  target-material: carrots[age=7]
  drop-item:
    item: mythic:my_mythic_item
    amount: 1