### PR TITLE
Fix Oraxen block loading integration

### DIFF
--- a/blockregen-plugin/src/main/java/nl/aurorion/blockregen/compatibility/material/OraxenMaterial.java
+++ b/blockregen-plugin/src/main/java/nl/aurorion/blockregen/compatibility/material/OraxenMaterial.java
@@ -4,7 +4,6 @@ import com.cryptomorin.xseries.XMaterial;
 import io.th0rgal.oraxen.api.OraxenBlocks;
 import io.th0rgal.oraxen.mechanics.Mechanic;
 import lombok.Getter;
-import nl.aurorion.blockregen.BlockRegenPlugin;
 import nl.aurorion.blockregen.material.BlockRegenMaterial;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.BlockData;

--- a/blockregen-plugin/src/main/java/nl/aurorion/blockregen/compatibility/provider/OraxenProvider.java
+++ b/blockregen-plugin/src/main/java/nl/aurorion/blockregen/compatibility/provider/OraxenProvider.java
@@ -3,7 +3,7 @@ package nl.aurorion.blockregen.compatibility.provider;
 import io.th0rgal.oraxen.api.OraxenBlocks;
 import io.th0rgal.oraxen.api.OraxenItems;
 import io.th0rgal.oraxen.items.ItemBuilder;
-import io.th0rgal.oraxen.mechanics.provided.gameplay.block.BlockMechanic;
+import io.th0rgal.oraxen.mechanics.Mechanic;
 import nl.aurorion.blockregen.BlockRegenPlugin;
 import nl.aurorion.blockregen.ParseException;
 import nl.aurorion.blockregen.compatibility.CompatibilityProvider;
@@ -61,11 +61,11 @@ public class OraxenProvider extends CompatibilityProvider implements ItemProvide
 
     @Override
     public @Nullable BlockRegenMaterial load(@NotNull Block block) {
-        BlockMechanic blockMechanic = OraxenBlocks.getBlockMechanic(block);
-        if (blockMechanic == null) {
+        Mechanic mechanic = OraxenBlocks.getOraxenBlock(block.getLocation());
+        if (mechanic == null) {
             return null;
         }
-        return new OraxenMaterial(blockMechanic.getItemID());
+        return new OraxenMaterial(mechanic.getItemID());
     }
 
     @Override


### PR DESCRIPTION
## Fixed Oraxen block loading integration.
  - **Summary** - Updated BlockRegen’s Oraxen compatibility to use the current Oraxen block API.
  - **Description** - BlockRegen now resolves Oraxen blocks through `OraxenBlocks.getOraxenBlock(...)`, restoring compatibility with newer Oraxen versions where the old block mechanic lookup is no longer available.
  - **Changes** - Replaced deprecated/removed `BlockMechanic` usage with generic `Mechanic` lookup in `OraxenProvider`, preserved Oraxen material reconstruction from mechanic item IDs, and removed an unused import.

Reason for this change is that the Oraxen block API changed.