### PR TITLE
fix: buckets bypassing Disable-Other-Break

### DIFF
--- a/blockregen-common/src/main/java/nl/aurorion/blockregen/regeneration/RegenerationEventType.java
+++ b/blockregen-common/src/main/java/nl/aurorion/blockregen/regeneration/RegenerationEventType.java
@@ -4,6 +4,8 @@ package nl.aurorion.blockregen.regeneration;
 public enum RegenerationEventType {
     BLOCK_BREAK,
     TRAMPLING,
+    // Picking up a liquid (water, lava,...) with a bucket.
+    BUCKET_FILL,
     // 1.16+
     HARVEST
 }

--- a/blockregen-plugin/src/main/java/nl/aurorion/blockregen/compatibility/provider/ResidenceProvider.java
+++ b/blockregen-plugin/src/main/java/nl/aurorion/blockregen/compatibility/provider/ResidenceProvider.java
@@ -24,7 +24,7 @@ public class ResidenceProvider extends CompatibilityProvider {
         if (residence != null) {
             ResidencePermissions permissions = residence.getPermissions();
 
-            if (type == RegenerationEventType.BLOCK_BREAK) {
+            if (type == RegenerationEventType.BLOCK_BREAK || type == RegenerationEventType.BUCKET_FILL) {
                 // has neither build nor destroy
                 // let residence run its protection
                 if (!permissions.playerHas(player, Flags.destroy, true) &&

--- a/blockregen-plugin/src/main/java/nl/aurorion/blockregen/listener/RegenerationListener.java
+++ b/blockregen-plugin/src/main/java/nl/aurorion/blockregen/listener/RegenerationListener.java
@@ -15,6 +15,7 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.player.PlayerBucketFillEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 
 @Log
@@ -95,5 +96,29 @@ public class RegenerationListener implements Listener {
                 event.setCancelled(true);
             }
         }, RegenerationEventType.BLOCK_BREAK);
+    }
+
+    // Picking up liquids with a bucket. Removes the source block without firing a BlockBreakEvent.
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onBucketFill(PlayerBucketFillEvent event) {
+        Player player = event.getPlayer();
+        Block block = event.getBlockClicked();
+
+        plugin.getRegenerationEventHandler().handleEvent(block, player, event, new EventControl<PlayerBucketFillEvent>() {
+            @Override
+            public void cancelDrops() {
+                // The bucket itself is the only 'drop', nothing to clear.
+            }
+
+            @Override
+            public void cancel() {
+                event.setCancelled(true);
+            }
+
+            @Override
+            public int getDefaultExperience() {
+                return 0;
+            }
+        }, RegenerationEventType.BUCKET_FILL);
     }
 }

--- a/blockregen-plugin/src/main/java/nl/aurorion/blockregen/regeneration/RegenerationEventHandlerImpl.java
+++ b/blockregen-plugin/src/main/java/nl/aurorion/blockregen/regeneration/RegenerationEventHandlerImpl.java
@@ -135,6 +135,13 @@ public class RegenerationEventHandlerImpl implements RegenerationEventHandler {
             return;
         }
 
+        // Liquids picked up with a bucket are only protected, never regenerated.
+        // The server clears the source block after the event, which would fight with the regeneration process.
+        if (type == RegenerationEventType.BUCKET_FILL) {
+            log.fine(() -> String.format("%s has a preset, but bucket fills are not regenerated.", block.getType()));
+            return;
+        }
+
         // Check preset permissions
         if (Permissions.lacksPermission(player, "blockregen.preset", preset.getName())) {
             Message.PERMISSION_BLOCK_ERROR.send(player);
@@ -253,7 +260,7 @@ public class RegenerationEventHandlerImpl implements RegenerationEventHandler {
         if (plugin.getConfig().getBoolean("WorldGuard-Support", true)
                 && plugin.getVersionManager().getWorldGuardProvider() != null) {
 
-            if (type == RegenerationEventType.BLOCK_BREAK) {
+            if (type == RegenerationEventType.BLOCK_BREAK || type == RegenerationEventType.BUCKET_FILL) {
                 if (!plugin.getVersionManager().getWorldGuardProvider().canBreak(player, block.getLocation())) {
                     log.fine(() -> "Let WorldGuard handle block break.");
                     return true;

--- a/blockregen-plugin/src/main/resources/Settings.yml
+++ b/blockregen-plugin/src/main/resources/Settings.yml
@@ -26,7 +26,8 @@ Use-Regions: true
 
 # Don't allow players to break blocks outside those configured for regeneration.
 #
-# Setting this to true protects all other blocks from being broken. No other protection is provided.
+# Setting this to true protects all other blocks from being broken, including liquids picked up with a bucket.
+# No other protection is provided.
 # Setting this to false allows the players to break any other block freely.
 Disable-Other-Break: true
 


### PR DESCRIPTION
## Problem

`Disable-Other-Break: true` does not protect liquids. Players can still drain water and lava out of protected worlds/regions by picking the source block up with a bucket.

Picking up a liquid fires `PlayerBucketFillEvent` and removes the source block directly — no `BlockBreakEvent` is ever fired. `RegenerationListener` only listens to `BlockBreakEvent`, `PlayerInteractEvent` (trampling) and `PlayerHarvestBlockEvent`, so the bucket path never reaches `RegenerationEventHandler` and none of the protection checks run.

### Reproduce

1. `Use-Regions: true`, `Disable-Other-Break: true`.
2. Create a BlockRegen region containing water, with no preset configured for `WATER`.
3. Overlap it with a WorldGuard region that has `block-break: allow` (so WorldGuard does not deny it itself).
4. Break a stone block inside the region → correctly denied.
5. Right-click the water with an empty bucket → the source block is removed.

## Fix

- New `RegenerationEventType.BUCKET_FILL`.
- `RegenerationListener` now handles `PlayerBucketFillEvent` and routes it through `RegenerationEventHandler` like any other break, so bypass, data check, world/region scope, `blockregen.region` / `blockregen.block` permissions and `Disable-Other-Break` all apply.
- `checkProtection` treats `BUCKET_FILL` like `BLOCK_BREAK` for WorldGuard and Residence, so those plugins keep handling the blocks they protect.
- Bucket fills are protected but never regenerated: the server clears the source block after the event, which would fight with a regeneration process. When a preset does exist for the liquid, the handler returns early and leaves the fill to vanilla.
- Documented the liquid case on `Disable-Other-Break` in `Settings.yml`.

## Notes

- `PlayerBucketFillEvent` and `getBlockClicked()` exist across every supported API version, so this needed no version module.
- Behaviour is unchanged when `Disable-Other-Break` is `false`, outside enabled worlds/regions, and for players with bypass.
- `PlayerBucketEmptyEvent` (placing liquids) is intentionally left alone — that is placing, not breaking.
